### PR TITLE
Fix: post -> userCard 연동 부분 createMany로 수정

### DIFF
--- a/src/repositories/UsersRepository.js
+++ b/src/repositories/UsersRepository.js
@@ -65,13 +65,15 @@ async function create(query) {
     },
   });
 
-  // 제작한 photoCard는 만든 이에게 귀속됨
-  await prisma.userCard.create({
-    data: {
-      photoCardId: photoCard.id,
-      ownerId: creatorId,
-      price: parseInt(price, 10),
-    },
+  // 제작한 photoCard는 만든 이에게 귀속됨 -- 발행량만큼 생성되어야 함
+  const userCards = Array.from({ length: parseInt(volumn, 10) }).map(() => ({
+    photoCardId: photoCard.id,
+    ownerId: creatorId,
+    price: parseInt(price, 10),
+  }));
+
+  await prisma.userCard.createMany({
+    data: userCards,
   });
 
   return photoCard;


### PR DESCRIPTION
# PR 유형 (x로 선택)

- [] `feat:` 새로운 기능을 추가
- [x] `fix:` 버그를 수정한 커밋
- [ ] `docs:` 문서 관련 수정
- [ ] `style:` 코드 스타일 관련 수정 (기능 변화 없음)
- [ ] `refactor:` 코드 리팩토링 (기능 변화 없음)

---

## 설명

기존에는 카드의 총 발행량이 3개라면 userCard도 3개 늘어나야 하는데, logic을 잘못 이해해서 카드 1개 만들어졌었음. 그걸 createMany를 이용해 여러 개가 만들어지도록 수정함.

---

## 상세 작업 내용

- 위와 같음

---

## 리뷰